### PR TITLE
feat(dependencies): Add Boost in the default environment

### DIFF
--- a/cpp/conanfile.txt
+++ b/cpp/conanfile.txt
@@ -1,12 +1,18 @@
 [requires]
 gtest/1.8.0@bincrafters/stable
+boost/1.70.0@conan/stable 
 
 [generators]
 cmake
 
 [imports]
 lib, *.pdb -> ./bin
+
 lib, libgmock*.a -> ./bin
 lib, gmock*.lib -> ./bin
+
 lib, libgtest*.a -> ./bin
 lib, gtest*.lib -> ./bin
+
+lib, *boost*.a -> ./bin
+lib, *boost*.lib -> ./bin


### PR DESCRIPTION
This PR add support for Boost library in default C++ environment.